### PR TITLE
Parenthetical with type of user now shows up on posts

### DIFF
--- a/public/openapi/components/schemas/UserObj.yaml
+++ b/public/openapi/components/schemas/UserObj.yaml
@@ -98,6 +98,9 @@ UserObj:
     groupTitle:
       type: string
       example: '["administrators","Staff"]'
+    displayGroupTitle:
+      type: string
+      example: "Administrator"
     groupTitleArray:
       type: array
       example:

--- a/public/openapi/components/schemas/UserObject.yaml
+++ b/public/openapi/components/schemas/UserObject.yaml
@@ -132,6 +132,10 @@ UserObject:
       type: string
       example: '["administrators","Staff"]'
       nullable: true
+    displayGroupTitle:
+      type: string
+      example: "Administrator"
+      nullable: true
     groupTitleArray:
       type: array
       example:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -126,6 +126,9 @@ get:
                               type: array
                               items:
                                 type: string
+                            displayGroupTitle:
+                              type: string
+                              nullable: true
                             icon:text:
                               type: string
                               description: A single-letter representation of a username. This is used in the

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -34,7 +34,6 @@ define('forum/topic', [
     });
 
 
-    //hang on. maybe its here
     Topic.init = function () {
         const tidChanged = !tid || parseInt(tid, 10) !== parseInt(ajaxify.data.tid, 10);
         tid = ajaxify.data.tid;

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -33,6 +33,8 @@ define('forum/topic', [
         }
     });
 
+
+    //hang on. maybe its here
     Topic.init = function () {
         const tidChanged = !tid || parseInt(tid, 10) !== parseInt(ajaxify.data.tid, 10);
         tid = ajaxify.data.tid;

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -32,6 +32,9 @@ Groups.systemGroups = [
     'unverified-users',
     Groups.BANNED_USERS,
     'administrators',
+    //no longer adding groups since account-type apparently exists smh
+    //'Instructors',
+    //'Students'
     'Global Moderators',
 ];
 

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -32,9 +32,8 @@ Groups.systemGroups = [
     'unverified-users',
     Groups.BANNED_USERS,
     'administrators',
-    //no longer adding groups since account-type apparently exists smh
-    //'Instructors',
-    //'Students'
+    // I thought I had to add students & instructors as groups but
+    // they're actually account types
     'Global Moderators',
 ];
 

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -104,14 +104,13 @@ module.exports = function (Posts) {
             'uid', 'username', 'fullname', 'userslug',
             'reputation', 'postcount', 'accounttype', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
-            'lastonline', 'groupTitle', 'mutedUntil', 'displayGroupTitle'
+            'lastonline', 'groupTitle', 'mutedUntil', 'displayGroupTitle',
         ];
         const result = await plugins.hooks.fire('filter:posts.addUserFields', {
             fields: fields,
             uid: uid,
             uids: uids,
         });
-        console.log("result: ", result);
         return await user.getUsersFields(result.uids, _.uniq(result.fields));
     }
 

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -102,7 +102,7 @@ module.exports = function (Posts) {
     async function getUserData(uids, uid) {
         const fields = [
             'uid', 'username', 'fullname', 'userslug',
-            'reputation', 'postcount', 'topiccount', 'picture',
+            'reputation', 'postcount', 'accounttype', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
             'lastonline', 'groupTitle', 'mutedUntil',
         ];
@@ -111,6 +111,7 @@ module.exports = function (Posts) {
             uid: uid,
             uids: uids,
         });
+        console.log("result: ", result);
         return await user.getUsersFields(result.uids, _.uniq(result.fields));
     }
 

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -104,7 +104,7 @@ module.exports = function (Posts) {
             'uid', 'username', 'fullname', 'userslug',
             'reputation', 'postcount', 'accounttype', 'topiccount', 'picture',
             'signature', 'banned', 'banned:expire', 'status',
-            'lastonline', 'groupTitle', 'mutedUntil',
+            'lastonline', 'groupTitle', 'mutedUntil', 'displayGroupTitle'
         ];
         const result = await plugins.hooks.fire('filter:posts.addUserFields', {
             fields: fields,

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -103,7 +103,7 @@ module.exports = function (Topics) {
         }
     }
 
-    //HERE. HERE is where user data is being passed to posts i believe.
+    // I think I finally found where user data is passed to posts
     Topics.addPostData = async function (postData, uid) {
         if (!Array.isArray(postData) || !postData.length) {
             return [];

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -103,6 +103,7 @@ module.exports = function (Topics) {
         }
     }
 
+    //HERE. HERE is where user data is being passed to posts i believe.
     Topics.addPostData = async function (postData, uid) {
         if (!Array.isArray(postData) || !postData.length) {
             return [];
@@ -124,7 +125,7 @@ module.exports = function (Topics) {
             posts.hasBookmarked(pids, uid),
             posts.getVoteStatusByPostIDs(pids, uid),
             getPostUserData('uid', async uids => await posts.getUserInfoForPosts(uids, uid)),
-            getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug'])),
+            getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug', 'accounttype'])),
             getPostReplies(pids, uid),
             Topics.addParentPosts(postData),
         ]);

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -220,18 +220,23 @@ module.exports = function (User) {
                 user.picture = User.getDefaultAvatar();
             }
 
+            //i believe hasOwnProperty is if the function is requesting this value returned, 
+            //not whether or not the value is null/empty/etc
             if (user.hasOwnProperty('displayGroupTitle')) {
-               // console.log("hello?")
-                //user.displayGroupTitle = user.accounttype.toString();
                 if(user.accounttype){
+                    //capitalizing the first letter of the account type (eg. 'student'-> 'Student')
                     user.displayGroupTitle = user.accounttype.toString().charAt(0).toUpperCase()+ user.accounttype.toString().slice(1);
+                }
+                else{
+                    //default value
+                    user.displayGroupTitle = "Student";
                 }
             }
 
+            //Admin is not a account type, it's a group title, so parse group title has been updated to also set displayGroupType 
+            //for admins. (['administrators'] -> 'Administrator')
             if (user.hasOwnProperty('groupTitle') || user.hasOwnProperty('groupTitleArray')) {
-               // console.log("entering grouptitle/grouptitle array: ", user.displayname, user.groupTitle, user.displayGroupTitle, user.groupTitleArray)
                 parseGroupTitle(user);
-                //console.log(user.groupTitle, user.displayGroupTitle, user.groupTitleArray)
             }
 
             if (user.picture && user.picture === user.uploadedpicture) {
@@ -312,8 +317,10 @@ module.exports = function (User) {
     function parseGroupTitle(user) {
         try {
             user.groupTitleArray = JSON.parse(user.groupTitle);
+            //setting displayGroupTitle if the user is an admin, since that's stored
+            //in a different place than if they're a student or instructor
                 if(user.groupTitleArray[0] == 'administrators'){
-                    user.displayGroupTitle = 'Administrator'
+                    user.displayGroupTitle = 'Administrator';
                 }
         } catch (err) {
             if (user.groupTitle) {
@@ -329,7 +336,6 @@ module.exports = function (User) {
                 
             } else {
                 user.groupTitleArray = [];
-                user.displayGroupTitle = 'Guest2';
             }
         }
         if (!meta.config.allowMultipleBadges && user.groupTitleArray.length) {

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -25,7 +25,7 @@ module.exports = function (User) {
         'aboutme', 'signature', 'uploadedpicture', 'profileviews', 'reputation',
         'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
         'status', 'flags', 'followerCount', 'followingCount', 'cover:url',
-        'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason',
+        'cover:position', 'groupTitle', 'displayGroupTitle', 'mutedUntil', 'mutedReason',
     ];
 
     User.guestData = {
@@ -39,6 +39,7 @@ module.exports = function (User) {
         'icon:bgColor': '#aaa',
         groupTitle: '',
         groupTitleArray: [],
+        displayGroupTitle: 'not entering function',
         status: 'offline',
         reputation: 0,
         'email:confirmed': 0,
@@ -294,16 +295,20 @@ module.exports = function (User) {
         } catch (err) {
             if (user.groupTitle) {
                 user.groupTitleArray = [user.groupTitle];
+                user.displayGroupTitle = user.groupTitle;
             } else {
                 user.groupTitle = '';
+                user.displayGroupTitle = 'Guest';
                 user.groupTitleArray = [];
             }
         }
         if (!Array.isArray(user.groupTitleArray)) {
             if (user.groupTitleArray) {
                 user.groupTitleArray = [user.groupTitleArray];
+                user.displayGroupTitle = user.groupTitle
             } else {
                 user.groupTitleArray = [];
+                user.displayGroupTitle = 'Guest';
             }
         }
         if (!meta.config.allowMultipleBadges && user.groupTitleArray.length) {

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -39,7 +39,7 @@ module.exports = function (User) {
         'icon:bgColor': '#aaa',
         groupTitle: '',
         groupTitleArray: [],
-        displayGroupTitle: 'not entering function',
+        displayGroupTitle: 'Guest',
         status: 'offline',
         reputation: 0,
         'email:confirmed': 0,
@@ -58,10 +58,13 @@ module.exports = function (User) {
 
         const uniqueUids = _.uniq(uids).filter(uid => uid > 0);
 
+        
         const results = await plugins.hooks.fire('filter:user.whitelistFields', {
             uids: uids,
+            //if fields is blank this is what they get set to. which i already added displayGroupTitle to???
             whitelist: fieldWhitelist.slice(),
         });
+        //if fields is blank set fields to results.whitelist
         if (!fields.length) {
             fields = results.whitelist;
         } else {
@@ -137,11 +140,13 @@ module.exports = function (User) {
         return users ? users[0] : null;
     };
 
+    //library.js calls this function
     User.getUserData = async function (uid) {
         const users = await User.getUsersData([uid]);
         return users ? users[0] : null;
     };
 
+    //getUserData calls getUsersData which calls getUserFields with an empty array 
     User.getUsersData = async function (uids) {
         return await User.getUsersFields(uids, []);
     };
@@ -295,7 +300,7 @@ module.exports = function (User) {
         } catch (err) {
             if (user.groupTitle) {
                 user.groupTitleArray = [user.groupTitle];
-                user.displayGroupTitle = user.groupTitle;
+                user.displayGroupTitle = "First";
             } else {
                 user.groupTitle = '';
                 user.displayGroupTitle = 'Guest';
@@ -305,7 +310,7 @@ module.exports = function (User) {
         if (!Array.isArray(user.groupTitleArray)) {
             if (user.groupTitleArray) {
                 user.groupTitleArray = [user.groupTitleArray];
-                user.displayGroupTitle = user.groupTitle
+                user.displayGroupTitle = "Second"
             } else {
                 user.groupTitleArray = [];
                 user.displayGroupTitle = 'Guest';

--- a/src/views/partials/data/topic.tpl
+++ b/src/views/partials/data/topic.tpl
@@ -1,1 +1,1 @@
-data-index="{posts.index}" data-pid="{posts.pid}" data-uid="{posts.uid}" data-timestamp="{posts.timestamp}" data-username="{posts.user.username}" data-userslug="{posts.user.userslug}" itemscope itemtype="http://schema.org/Comment"
+data-index="{posts.index}" data-pid="{posts.pid}" data-uid="{posts.uid}" data-timestamp="{posts.timestamp}" data-username="{posts.user.username}" data-userslug="{posts.user.userslug}" data-accounttype="{posts.user.displayGroupTitle}" itemscope itemtype="http://schema.org/Comment"

--- a/themes/nodebb-theme-persona/library.js
+++ b/themes/nodebb-theme-persona/library.js
@@ -87,6 +87,7 @@ library.getThemeConfig = async function (config) {
 };
 
 //I think this is where the data is being passed to topic template
+//no its not. 
 library.addUserToTopic = async function (hookData) {
     const settings = await meta.settings.get('persona');
     if (settings.enableQuickReply === 'on') {

--- a/themes/nodebb-theme-persona/library.js
+++ b/themes/nodebb-theme-persona/library.js
@@ -86,6 +86,7 @@ library.getThemeConfig = async function (config) {
     return config;
 };
 
+//I think this is where the data is being passed to topic template
 library.addUserToTopic = async function (hookData) {
     const settings = await meta.settings.get('persona');
     if (settings.enableQuickReply === 'on') {

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,7 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}, change here</a>
+            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.groupTitle})</a>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,7 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.groupTitle})</a>
+            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.groupTitleArray})</a>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,7 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.displayGroupTitle})</a>
+            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" id= "name-display" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.displayGroupTitle})</a>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,7 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}, change here</a>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,7 +8,7 @@
 
     <small class="pull-left">
         <strong>
-            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.groupTitleArray})</a>
+            <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname} ({posts.user.displayGroupTitle})</a>
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->


### PR DESCRIPTION
### Functionality

Users are now able to see the type of user who created a post or comment (e.g., instructors, students, or administrators) as a parenthetical next to their usernames.

### Changes

Added a new field to the user object called displayGroupName to store the user's group/account type in a friendlier format. Also made some minor edits to the ```getUserData()``` function in ```src/posts/user```, so said new field would be passed to the post template and able to display. 

### Notes:

Because of the changes to the database, re-intializing NodeBB from scratch when running these changes may be necessary, if they do not show up immediately. 

A majority of time spent working on this issue was trying to understand where the user data was passed to the post template; how the various getUser(s)Data/Fields functions worked, and how to add fields to the database, in addition to discovering that ```accounttype``` was the field that I was looking for for students and instructors, but ```groupTitle``` stored whether or not a user was an administrator. This issue was made much more manageable when I figured out how to use the console to print-debug, as before I simply had no way to check if any of my changes were making a difference. 

This pull request closes #6. 

![image](https://github.com/CMU-313/spring24-nodebb-over-20/assets/99108232/2efe64a5-ec9a-4ed3-b24f-e6ffe06d99dd)
